### PR TITLE
Adds a grid of PlayerCard Templates

### DIFF
--- a/RoyalFactorial/MainWindow.xaml
+++ b/RoyalFactorial/MainWindow.xaml
@@ -101,10 +101,10 @@
         </Grid>
 
         <Grid Grid.Row="1"
-            Grid.Column="1">
+              Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <!-- Main Content -->
-                <ColumnDefinition Width="200"/>
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <!-- Card Game Section -->
@@ -113,8 +113,25 @@
                 <RowDefinition Height="60"/>
             </Grid.RowDefinitions>
 
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalAlignment="Stretch"
+                          Padding="10"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Background="{StaticResource BackgroundColor}"
+                          BorderBrush="{StaticResource BorderGrayColor}"
+                          BorderThickness="1">
+                <ItemsControl ItemsSource="{Binding Players}"
+                              ItemTemplate="{StaticResource PlayerCardTemplate}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </ScrollViewer>
         </Grid>
 
     </Grid>
-
+    
 </Window>

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -45,5 +45,75 @@
         </Grid>
     </DataTemplate>
 
+    <DataTemplate x:Key="PlayerCardTemplate"
+                  DataType="{x:Type local:Player}">
+        <Border Margin="10"
+                BorderBrush="{StaticResource BorderGrayColor}"
+                BorderThickness="1"
+                Background="{StaticResource InteractiveBackgroundColor}"
+                CornerRadius="5"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch">
+            <Grid HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Margin="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
+                <!-- PlayerCard Header -->
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Text="{Binding Name}"
+                           FontWeight="Bold"
+                           Foreground="{StaticResource ForegroundColor}"
+                           Margin="10"/>
+
+                <!-- Player Position -->
+                <TextBlock Grid.Row="0"
+                           Grid.Column="1"
+                           VerticalAlignment="Center"
+                           TextAlignment="Right"
+                           Foreground="{StaticResource PrimaryColor}"
+                           FontSize="18"
+                           FontWeight="DemiBold"
+                           Margin="10">
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="#{0}">
+                            <Binding Path="Position" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+
+                <!-- Player Hand Section -->
+                <StackPanel Grid.Row="1"
+                            Grid.Column="0"
+                            VerticalAlignment="Stretch"
+                            HorizontalAlignment="Stretch"
+                            Background="{StaticResource InteractiveGrayBackgroundColor}">
+                </StackPanel>
+
+                <!-- Player Stats Panel -->
+                <StackPanel Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="8,0,8,0">
+                    <TextBlock Text="Rank Score:"
+                            Margin="0, 0, 0, 5"
+                            TextWrapping="Wrap"
+                            FontWeight="DemiBold"
+                            Foreground="{StaticResource TextColor}"/>
+                    <TextBlock Text="{Binding RankScore}"
+                            Foreground="{StaticResource TextColor}"
+                            FontSize="14"
+                            Padding="0,0,5,5"
+                            FontWeight="DemiBold"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </DataTemplate>
 </ResourceDictionary>


### PR DESCRIPTION
- Adds a card for each player to the main grid section to display their hand, rank score and position.

- Displays according to the original unordered list of players
  - In games with many plays it would be inconvenient to look for cards each time they sort.
  - The leaderboard already communicates leaderboard information, and cards have position elements for good measure.

- Uses WrapPanel for player card dimensions for responsive design.

Test Evidence: 

![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/ed79d8c1-24b0-4505-b55d-072d7f3b169d)

