### PR TITLE
Feature/player card hands visualizer

### DIFF
--- a/RoyalFactorial/MainWindow.xaml
+++ b/RoyalFactorial/MainWindow.xaml
@@ -82,8 +82,35 @@
                    Foreground="{StaticResource TextAccentColor}"
                    Margin="8,0,0,0"/>
 
+            <StackPanel Margin="4,0,4,0"
+                        Grid.Row="1"
+                        Background="Transparent">
+                <Grid Margin="4,0,4,0"
+                      Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="50"/>
+                        <ColumnDefinition Width="50"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-            <ListBox ItemTemplate="{StaticResource LeaderboardEntryTemplate}"
+                    <TextBlock Text="Place"
+                               FontWeight="Bold"
+                               Padding="5"
+                               Foreground="{StaticResource TextColor}" />
+                    <TextBlock Text="Player"
+                               Grid.Column="1"
+                               FontWeight="Bold"
+                               Padding="5"
+                               Foreground="{StaticResource TextColor}" />
+                    <TextBlock Text="Points"
+                               Grid.Column="2"
+                               FontWeight="Bold"
+                               Padding="5"
+                               TextAlignment="Right"
+                               Foreground="{StaticResource TextColor}" />
+                </Grid>
+
+                <ListBox ItemTemplate="{StaticResource LeaderboardEntryTemplate}"
                      ItemsSource="{Binding Leaderboard.Players}"     
                      HorizontalAlignment="Stretch"
                      HorizontalContentAlignment="Stretch"
@@ -91,7 +118,8 @@
                      VerticalAlignment="Top"
                      BorderThickness="0"
                      Background="Transparent">
-            </ListBox>
+                </ListBox>
+            </StackPanel>
 
             <Button Content="Shuffle And Deal" 
                     Command="{Binding ShuffleAndDealCommand}"

--- a/RoyalFactorial/MainWindow.xaml
+++ b/RoyalFactorial/MainWindow.xaml
@@ -129,10 +129,10 @@
         </Grid>
 
         <Grid Grid.Row="1"
-            Grid.Column="1">
+              Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <!-- Main Content -->
-                <ColumnDefinition Width="200"/>
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <!-- Card Game Section -->
@@ -141,8 +141,25 @@
                 <RowDefinition Height="60"/>
             </Grid.RowDefinitions>
 
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalAlignment="Stretch"
+                          Padding="10"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Background="{StaticResource BackgroundColor}"
+                          BorderBrush="{StaticResource BorderGrayColor}"
+                          BorderThickness="1">
+                <ItemsControl ItemsSource="{Binding Players}"
+                              ItemTemplate="{StaticResource PlayerCardTemplate}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </ScrollViewer>
         </Grid>
 
     </Grid>
-
+    
 </Window>

--- a/RoyalFactorial/MainWindow.xaml
+++ b/RoyalFactorial/MainWindow.xaml
@@ -153,13 +153,18 @@
                               ItemTemplate="{StaticResource PlayerCardTemplate}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
+                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" MinWidth="200"/>
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="MaxWidth" Value="700"/>
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
                 </ItemsControl>
             </ScrollViewer>
         </Grid>
 
     </Grid>
-    
+
 </Window>

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -45,5 +45,75 @@
         </Grid>
     </DataTemplate>
 
+    <DataTemplate x:Key="PlayerCardTemplate"
+                  DataType="{x:Type local:Player}">
+        <Border Margin="10"
+                BorderBrush="{StaticResource BorderGrayColor}"
+                BorderThickness="1"
+                Background="{StaticResource InteractiveBackgroundColor}"
+                CornerRadius="5"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch">
+            <Grid HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Margin="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
+                <!-- PlayerCard Header -->
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Text="{Binding Name}"
+                           FontWeight="Bold"
+                           Foreground="{StaticResource ForegroundColor}"
+                           Margin="10"/>
+
+                <!-- Player Position -->
+                <TextBlock Grid.Row="0"
+                           Grid.Column="1"
+                           VerticalAlignment="Center"
+                           TextAlignment="Right"
+                           Foreground="{StaticResource PrimaryColor}"
+                           FontSize="18"
+                           FontWeight="DemiBold"
+                           Margin="10">
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="#{0}">
+                            <Binding Path="Position" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+
+                <!-- Player Hand Section -->
+                <StackPanel Grid.Row="1"
+                            Grid.Column="0"
+                            VerticalAlignment="Stretch"
+                            HorizontalAlignment="Stretch"
+                            Background="{StaticResource InteractiveGrayBackgroundColor}">
+                </StackPanel>
+
+                <!-- Player Stats Panel -->
+                <StackPanel Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="8,0,8,0">
+                    <TextBlock Text="Rank Score:"
+                            Margin="0, 0, 0, 5"
+                            TextWrapping="Wrap"
+                            FontWeight="DemiBold"
+                            Foreground="{StaticResource TextColor}"/>
+                    <TextBlock Text="{Binding RankScore}"
+                            Foreground="{StaticResource TextColor}"
+                            FontSize="14"
+                            Padding="0,0,5,5"
+                            FontWeight="DemiBold"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </DataTemplate>
 </ResourceDictionary>

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -6,8 +6,7 @@
                   DataType="{x:Type local:Player}">
         <Grid Background="Transparent"
               HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch"
-              Margin="0">
+              VerticalAlignment="Stretch">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="50"/>
                 <ColumnDefinition />
@@ -17,25 +16,26 @@
             <TextBlock HorizontalAlignment="Left"
                        FontWeight="Bold"
                        Foreground="{StaticResource TextColor}"
-                       Padding="5">
+                       Padding="3">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="#{0}">
                         <Binding Path="Position" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
+
             <TextBlock Grid.Column="1"
                        HorizontalAlignment="Left"
                        Text="{Binding Name}"
                        Foreground="{StaticResource TextColor}"
-                       Padding="5">
+                       Padding="3">
             </TextBlock>
 
             <TextBlock Grid.Column="2"
                        HorizontalAlignment="Right"
                        TextAlignment="Right"
                        Foreground="{StaticResource TextAccentColor}"
-                       Padding="5">
+                       Padding="3">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="+{0}">
                         <Binding Path="RankScore" />

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -91,12 +91,71 @@
                 </TextBlock>
 
                 <!-- Player Hand Section -->
-                <StackPanel Grid.Row="1"
-                            Grid.Column="0"
-                            VerticalAlignment="Stretch"
-                            HorizontalAlignment="Stretch"
-                            Background="{StaticResource InteractiveGrayBackgroundColor}">
-                </StackPanel>
+                <ScrollViewer Grid.Row="1"
+                              Grid.Column="0"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled"
+                              VerticalAlignment="Center"
+                              Margin="10"
+                              Background="{StaticResource InteractiveGrayBackgroundColor}"
+                              BorderBrush="{StaticResource BorderGrayColor}"
+                              BorderThickness="1">
+                    <ItemsControl ItemsSource="{Binding Hand}">
+
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" ItemWidth="50" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderThickness="1"
+                                        BorderBrush="{StaticResource BorderColor}"
+                                        Background="{StaticResource ForegroundColor}">
+                                    <StackPanel Margin="5"
+                                                Background="{StaticResource WhiteColor}">
+
+                                        <StackPanel Orientation="Horizontal"
+                                                    HorizontalAlignment="Stretch">
+                                            <TextBlock Text="{Binding Rank.Symbol}"
+                                                       Margin="0,0,8,0"
+                                                       Padding="2"
+                                                       Foreground="{StaticResource TextColor}"/>
+                                            <TextBlock Text="{Binding Suit.Symbol}"
+                                                       Margin="0,0,8,0"
+                                                       Padding="2"
+                                                       Foreground="{StaticResource PrimaryColor}"/>
+                                        </StackPanel
+                                    >
+                                        <TextBlock Foreground="{StaticResource TextColor}"
+                                                   HorizontalAlignment="Stretch"
+                                                   Padding="2"
+                                                   TextAlignment="Right">
+                                            <TextBlock.Text>
+                                                <MultiBinding StringFormat="+{0}">
+                                                    <Binding Path="Rank.Score" />
+                                                </MultiBinding>
+                                            </TextBlock.Text>
+                                        </TextBlock>
+
+                                        <TextBlock Foreground="{StaticResource PrimaryColor}"
+                                                   Padding="2"
+                                                   HorizontalAlignment="Stretch"
+                                                   TextAlignment="Right">
+                                            <TextBlock.Text>
+                                                <MultiBinding StringFormat="x{0}">
+                                                    <Binding Path="Suit.Score" />
+                                                </MultiBinding>
+                                            </TextBlock.Text>
+                                        </TextBlock>
+
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
 
                 <!-- Player Stats Panel -->
                 <StackPanel Grid.Row="1"
@@ -117,3 +176,4 @@
         </Border>
     </DataTemplate>
 </ResourceDictionary>
+    


### PR DESCRIPTION
- Visually displays card information as cards.

- Uses WrapPanel on Card elements to enforce constant widths regardless of inner card content.

- Targets the ItemControl's content presenter to create more appealing 'breakpoints' on large window sizes.

## Test Evidence: 
![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/2fa25f66-af81-4a1d-a5ad-13d40acfc014)

![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/0ad44cc7-4445-4743-a5b1-bce4cd8b10a9)
