### PR TITLE
Feature/conditional rendering of suit score

### DIFF
--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -13,6 +13,7 @@
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
+            <!-- Position -->
             <TextBlock HorizontalAlignment="Left"
                        FontWeight="Bold"
                        Foreground="{StaticResource TextColor}"
@@ -24,6 +25,7 @@
                 </TextBlock.Text>
             </TextBlock>
 
+            <!-- Name -->
             <TextBlock Grid.Column="1"
                        HorizontalAlignment="Left"
                        Text="{Binding Name}"
@@ -31,17 +33,57 @@
                        Padding="3">
             </TextBlock>
 
+            <!-- Rank Score -->
             <TextBlock Grid.Column="2"
                        HorizontalAlignment="Right"
                        TextAlignment="Right"
                        Foreground="{StaticResource TextAccentColor}"
-                       Padding="3">
+                       Padding="3"
+                       Style="{StaticResource HiddenIfTiedFirst}">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="+{0}">
                         <Binding Path="RankScore" />
                     </MultiBinding>
                 </TextBlock.Text>
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsTiedFirst}"
+                                         Value="True">
+                                <Setter Property="Visibility"
+                                        Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
             </TextBlock>
+
+            <!-- Suite Score -->
+            <TextBlock Grid.Column="2"
+                       HorizontalAlignment="Right"
+                       TextAlignment="Right"
+                       Foreground="{StaticResource TextAccentColor}"
+                       Padding="3"
+                       Style="{StaticResource VisibleIfTiedFirst}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="x{0}">
+                        <Binding Path="SuitScore" />
+                    </MultiBinding>
+                </TextBlock.Text>
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsTiedFirst}"
+                                         Value="False">
+                                <Setter Property="Visibility"
+                                        Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+
+
         </Grid>
     </DataTemplate>
 
@@ -126,8 +168,8 @@
                                                        Margin="0,0,8,0"
                                                        Padding="2"
                                                        Foreground="{StaticResource PrimaryColor}"/>
-                                        </StackPanel
-                                    >
+                                        </StackPanel>
+
                                         <TextBlock Foreground="{StaticResource TextColor}"
                                                    HorizontalAlignment="Stretch"
                                                    Padding="2"
@@ -166,11 +208,32 @@
                             TextWrapping="Wrap"
                             FontWeight="DemiBold"
                             Foreground="{StaticResource TextColor}"/>
+
                     <TextBlock Text="{Binding RankScore}"
                             Foreground="{StaticResource TextColor}"
                             FontSize="14"
                             Padding="0,0,5,5"
                             FontWeight="DemiBold"/>
+
+                    <TextBlock Text="Suit Factor:"
+                               TextWrapping="Wrap" 
+                               Margin="0, 0, 0, 5"
+                               FontWeight="DemiBold"
+                               Foreground="{StaticResource PrimaryColor}"/>
+
+                    <TextBlock Text="{Binding SuitScore}"
+                               Foreground="{StaticResource PrimaryColor}"
+                               FontSize="14"
+                               Padding="0,0,5,5"
+                               FontWeight="DemiBold"
+                               Style="{StaticResource VisibleIfTiedFirst}"/>
+
+                    <TextBlock Text="??"
+                               Foreground="{StaticResource PrimaryColor}"
+                               FontSize="14"
+                               Padding="0,0,5,0"
+                               FontWeight="DemiBold"
+                               Style="{StaticResource HiddenIfTiedFirst}"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -45,17 +45,6 @@
                         <Binding Path="RankScore" />
                     </MultiBinding>
                 </TextBlock.Text>
-                <TextBlock.Style>
-                    <Style TargetType="TextBlock">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsTiedFirst}"
-                                         Value="True">
-                                <Setter Property="Visibility"
-                                        Value="Collapsed"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBlock.Style>
             </TextBlock>
 
             <!-- Suite Score -->
@@ -70,17 +59,6 @@
                         <Binding Path="SuitScore" />
                     </MultiBinding>
                 </TextBlock.Text>
-                <TextBlock.Style>
-                    <Style TargetType="TextBlock">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsTiedFirst}"
-                                         Value="False">
-                                <Setter Property="Visibility"
-                                        Value="Collapsed"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBlock.Style>
             </TextBlock>
 
 
@@ -204,16 +182,16 @@
                             Grid.Column="1"
                             Margin="8,0,8,0">
                     <TextBlock Text="Rank Score:"
-                            Margin="0, 0, 0, 5"
-                            TextWrapping="Wrap"
-                            FontWeight="DemiBold"
-                            Foreground="{StaticResource TextColor}"/>
+                               Margin="0, 0, 0, 5"
+                               TextWrapping="Wrap"
+                               FontWeight="DemiBold"
+                               Foreground="{StaticResource TextColor}"/>
 
                     <TextBlock Text="{Binding RankScore}"
-                            Foreground="{StaticResource TextColor}"
-                            FontSize="14"
-                            Padding="0,0,5,5"
-                            FontWeight="DemiBold"/>
+                               Foreground="{StaticResource TextColor}"
+                               FontSize="14"
+                               Padding="0,0,5,5"
+                               FontWeight="DemiBold"/>
 
                     <TextBlock Text="Suit Factor:"
                                TextWrapping="Wrap" 

--- a/RoyalFactorial/Themes/Styles.xaml
+++ b/RoyalFactorial/Themes/Styles.xaml
@@ -23,4 +23,23 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style x:Key="VisibleIfTiedFirst" TargetType="TextBlock">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsTiedFirst}" Value="False">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="HiddenIfTiedFirst" TargetType="TextBlock">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsTiedFirst}"
+                    Value="True">
+                <Setter Property="Visibility"
+                Value="Collapsed"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
- Conditionally renders the Suit Score for tied players instead of the Rank Score in the leaderboards.

- Player's Rank Scores can be found on their player cards if needed.

- Conditionally renders the calculated Suit Score on Tied Players' cards and renders '??' on non-tied players' scores.

- Does not conditionally render the score on the playing cards as it ruins the 'card' look.

- Uses ResourceDictionary to implement the conditional rendering styles. This saves 11 lines of XAML each time it's used.

## Test Evidence


### Case 1
- No tied players exist
![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/0de8ef51-179f-4763-a4f7-c05570c83618)

### Case 2
- Tied players exist but are not tied for first
![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/5f920347-6d05-4e62-82d0-e9bd4182ef5e)
 
### Case 3
- Players are tied for first
![image](https://github.com/shgnplaatjies/RoyalFactorial/assets/63879125/d744a2e8-edfe-4648-ae5b-a515b4c6f246)
