### PR TITLE
Optimizes Suit Score Calculation Best case O(n) > Best case O(1)

### DIFF
--- a/RoyalFactorial/MVVM/Model/Card.cs
+++ b/RoyalFactorial/MVVM/Model/Card.cs
@@ -8,10 +8,9 @@ namespace RoyalFactorial.MVVM.Model
 {
     public record Card(Suit Suit, Rank Rank)
     {
-        public int GetRankScore() => Rank.Score;
+        public int RankScore { get; } = Rank.Score;
 
-        public int GetSuitScore() => Suit.Score;
-
+        public int SuitScore { get; } = Suit.Score;
         public override string ToString() => $"Card<{Rank},{Suit}>";
 
         public static List<Rank> GetRanks() =>

--- a/RoyalFactorial/MVVM/Model/Player.cs
+++ b/RoyalFactorial/MVVM/Model/Player.cs
@@ -9,7 +9,7 @@ namespace RoyalFactorial.MVVM.Model
     public class Player(string Name, List<Card> Hand)
     {
         public int RankScore { get; } = CalculateRankScore(Hand);
-        public int GetSuitScore => CalculateSuitScore(Hand);
+        public int GetSuitScore => CalculateSuitScore(Hand, IsTiedFirst);
         public string Name { get; } = Name;
         public int? Position { get; set; }
         public bool? IsTiedFirst { get; set; }
@@ -20,12 +20,15 @@ namespace RoyalFactorial.MVVM.Model
         private static int CalculateRankScore(List<Card> hand) =>
             hand.Sum(_ => _.RankScore);
 
-        private static int CalculateSuitScore(List<Card> hand) => hand
-            .Aggregate
+        private static int CalculateSuitScore(List<Card> hand, bool? isTiedFirst)
+        {
+            if (!(isTiedFirst ?? false)) return -1;
+
+            return hand.Aggregate
             (
                 1,
                 (product, card) => product * card.SuitScore
             );
-
+        }
     }
 }

--- a/RoyalFactorial/MVVM/Model/Player.cs
+++ b/RoyalFactorial/MVVM/Model/Player.cs
@@ -9,22 +9,22 @@ namespace RoyalFactorial.MVVM.Model
     public class Player(string Name, List<Card> Hand)
     {
         public int RankScore { get; } = CalculateRankScore(Hand);
-        public int SuitScore { get; } = CalculateSuitScore(Hand);
+        public int GetSuitScore => CalculateSuitScore(Hand);
         public string Name { get; } = Name;
         public int? Position { get; set; }
         public bool? IsTiedFirst { get; set; }
 
         public List<Card> Hand { get; } = new(Hand
-            .OrderByDescending(_ => _.GetRankScore()));
+            .OrderByDescending(_ => _.RankScore));
 
         private static int CalculateRankScore(List<Card> hand) =>
-            hand.Sum(_ => _.GetRankScore());
+            hand.Sum(_ => _.RankScore);
 
         private static int CalculateSuitScore(List<Card> hand) => hand
             .Aggregate
             (
                 1,
-                (product, card) => product * card.GetSuitScore()
+                (product, card) => product * card.SuitScore
             );
 
     }

--- a/RoyalFactorial/Themes/DataTemplates.xaml
+++ b/RoyalFactorial/Themes/DataTemplates.xaml
@@ -57,7 +57,7 @@
                        Style="{StaticResource VisibleIfTiedFirst}">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="x{0}">
-                        <Binding Path="SuitScore" />
+                        <Binding Path="GetSuitScore" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
@@ -217,7 +217,7 @@
                                FontWeight="DemiBold"
                                Foreground="{StaticResource PrimaryColor}"/>
 
-                    <TextBlock Text="{Binding SuitScore}"
+                    <TextBlock Text="{Binding GetSuitScore}"
                                Foreground="{StaticResource PrimaryColor}"
                                FontSize="14"
                                Padding="0,0,5,5"


### PR DESCRIPTION
- Refactored Card's SuitScore and RankScore fields from functions that return the scores, to a field that returns scores.

- Refactored Player model as a method that returns an int, this lazily calculates the Suit score

GetSuitScore now includes a check for isTiedFirst to determine whether it will execute.

- Small change to align closer to the spec, it requires Suit Scores to be calculated for tied players vs only shown for tied players.

## Big O Analysis
- best case: O(1) when not tied.
- worst case: O(n) when tied.